### PR TITLE
Respect executable bit of file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Options:
   -C, --directory string   Change to directory before copy
       --dry-run            Upload files but do not update the branch actually
   -m, --message string     Commit message (mandatory)
+      --no-file-mode       Ignore executable bit of file and treat as 0644
   -u, --owner string       GitHub repository owner (mandatory)
   -r, --repo string        GitHub repository name (mandatory)
       --token string       GitHub API token [$GITHUB_TOKEN]

--- a/adaptors/cmd.go
+++ b/adaptors/cmd.go
@@ -65,6 +65,7 @@ func (c *Cmd) Run(ctx context.Context, args []string) int {
 	f.StringVarP(&o.Branch, "branch", "b", "", "Branch name (default: default branch of repository)")
 	f.StringVarP(&o.Chdir, "directory", "C", "", "Change to directory before copy")
 	f.StringVar(&o.GitHubToken, "token", "", fmt.Sprintf("GitHub API token [$%s]", envGitHubToken))
+	f.BoolVar(&o.NoFileMode, "no-file-mode", false, "Ignore executable bit of file and treat as 0644")
 	f.BoolVar(&o.DryRun, "dry-run", false, "Upload files but do not update the branch actually")
 	f.BoolVar(&o.Debug, "debug", false, "Show debug logs")
 
@@ -114,6 +115,7 @@ func (c *Cmd) copy(ctx context.Context, o copyOptions) int {
 		CommitMessage: git.CommitMessage(o.CommitMessage),
 		BranchName:    git.BranchName(o.Branch),
 		Paths:         o.Paths,
+		NoFileMode:    o.NoFileMode,
 		DryRun:        o.DryRun,
 	}); err != nil {
 		c.Logger.Errorf("Could not copy files: %s", err)
@@ -128,6 +130,7 @@ type copyOptions struct {
 	CommitMessage   string
 	Branch          string // optional
 	Paths           []string
+	NoFileMode      bool
 	DryRun          bool
 }
 

--- a/adaptors/cmd_test.go
+++ b/adaptors/cmd_test.go
@@ -87,6 +87,42 @@ func TestCmd_Run(t *testing.T) {
 		}
 	})
 
+	t.Run("--no-file-mode", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		copyUseCase := mock_usecases.NewMockCopyUseCase(ctrl)
+		copyUseCase.EXPECT().
+			Do(ctx, usecases.CopyUseCaseIn{
+				Repository:    git.RepositoryID{Owner: "owner", Name: "repo"},
+				CommitMessage: "commit-message",
+				Paths:         []string{"file1", "file2"},
+				NoFileMode:    true,
+			})
+
+		cmd := Cmd{
+			CopyUseCase:      copyUseCase,
+			Env:              mock_adaptors.NewMockEnv(ctrl),
+			Logger:           mock_adaptors.NewLogger(t),
+			LoggerConfig:     mock_adaptors.NewMockLoggerConfig(ctrl),
+			GitHubClientInit: newGitHubClientInit(ctrl, infrastructure.GitHubClientInitOptions{Token: "YOUR_TOKEN"}),
+		}
+		args := []string{
+			cmdName,
+			"--token", "YOUR_TOKEN",
+			"-u", "owner",
+			"-r", "repo",
+			"-m", "commit-message",
+			"--no-file-mode",
+			"file1",
+			"file2",
+		}
+		exitCode := cmd.Run(ctx, args)
+		if exitCode != exitCodeOK {
+			t.Errorf("exitCode wants %d but %d", exitCodeOK, exitCode)
+		}
+	})
+
 	t.Run("--dry-run", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()

--- a/adaptors/fs.go
+++ b/adaptors/fs.go
@@ -19,8 +19,8 @@ func NewFileSystem() adaptors.FileSystem {
 type FileSystem struct{}
 
 // FindFiles returns a list of files in the paths.
-func (fs *FileSystem) FindFiles(paths []string) ([]string, error) {
-	var files []string
+func (fs *FileSystem) FindFiles(paths []string) ([]adaptors.File, error) {
+	var files []adaptors.File
 	for _, path := range paths {
 		if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -29,7 +29,10 @@ func (fs *FileSystem) FindFiles(paths []string) ([]string, error) {
 			if !info.Mode().IsRegular() {
 				return nil
 			}
-			files = append(files, path)
+			files = append(files, adaptors.File{
+				Path:       path,
+				Executable: info.Mode()&0100 != 0, // mask the executable bit of owner
+			})
 			return nil
 		}); err != nil {
 			return nil, errors.Wrapf(err, "error while finding files in %s", path)

--- a/adaptors/fs_test.go
+++ b/adaptors/fs_test.go
@@ -1,4 +1,4 @@
-package adaptors_test
+package adaptors
 
 import (
 	"fmt"
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/int128/ghcp/adaptors"
+	"github.com/int128/ghcp/adaptors/interfaces"
 )
 
 func TestFileSystem_FindFiles(t *testing.T) {
-	fs := &adaptors.FileSystem{}
+	fs := &FileSystem{}
 	tempDir, err := ioutil.TempDir("", "FindFiles")
 	if err != nil {
 		t.Fatal(err)
@@ -32,7 +32,7 @@ func TestFileSystem_FindFiles(t *testing.T) {
 	if err := ioutil.WriteFile("dir2/b.jpg", []byte{}, 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile("dir2/c.jpg", []byte{}, 0644); err != nil {
+	if err := ioutil.WriteFile("dir2/c.jpg", []byte{}, 0755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -41,7 +41,11 @@ func TestFileSystem_FindFiles(t *testing.T) {
 		if err != nil {
 			t.Fatalf("FindFiles returned error: %+v", err)
 		}
-		wants := []string{"dir1/a.jpg", "dir2/b.jpg", "dir2/c.jpg"}
+		wants := []adaptors.File{
+			{Path: "dir1/a.jpg"},
+			{Path: "dir2/b.jpg"},
+			{Path: "dir2/c.jpg", Executable: true},
+		}
 		if diff := deep.Equal(wants, files); diff != nil {
 			t.Error(diff)
 		}
@@ -51,7 +55,10 @@ func TestFileSystem_FindFiles(t *testing.T) {
 		if err != nil {
 			t.Fatalf("FindFiles returned error: %+v", err)
 		}
-		wants := []string{"dir1/a.jpg", "dir2/c.jpg"}
+		wants := []adaptors.File{
+			{Path: "dir1/a.jpg"},
+			{Path: "dir2/c.jpg", Executable: true},
+		}
 		if diff := deep.Equal(wants, files); diff != nil {
 			t.Error(diff)
 		}
@@ -68,7 +75,7 @@ func TestFileSystem_FindFiles(t *testing.T) {
 }
 
 func TestFileSystem_ReadAsBase64EncodedContent(t *testing.T) {
-	fs := &adaptors.FileSystem{}
+	fs := &FileSystem{}
 	tempFile := makeTempFile(t, "hello\nworld")
 	defer os.RemoveAll(tempFile)
 	content, err := fs.ReadAsBase64EncodedContent(tempFile)

--- a/adaptors/interfaces/adaptors.go
+++ b/adaptors/interfaces/adaptors.go
@@ -20,8 +20,13 @@ type CmdOptions struct {
 }
 
 type FileSystem interface {
-	FindFiles(paths []string) ([]string, error)
+	FindFiles(paths []string) ([]File, error)
 	ReadAsBase64EncodedContent(filename string) (string, error)
+}
+
+type File struct {
+	Path       string
+	Executable bool
 }
 
 type Env interface {

--- a/adaptors/mock_adaptors/mock_adaptors.go
+++ b/adaptors/mock_adaptors/mock_adaptors.go
@@ -71,9 +71,9 @@ func (m *MockFileSystem) EXPECT() *MockFileSystemMockRecorder {
 }
 
 // FindFiles mocks base method
-func (m *MockFileSystem) FindFiles(arg0 []string) ([]string, error) {
+func (m *MockFileSystem) FindFiles(arg0 []string) ([]interfaces.File, error) {
 	ret := m.ctrl.Call(m, "FindFiles", arg0)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]interfaces.File)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/usecases/copy.go
+++ b/usecases/copy.go
@@ -38,52 +38,8 @@ func (u *CopyUseCase) Do(ctx context.Context, in usecases.CopyUseCaseIn) error {
 	}
 	u.Logger.Infof("Logged in as %s", out.CurrentUserName)
 
-	if in.BranchName == "" {
-		// copy to the default branch
-		if err := u.copyToExistingBranch(ctx, copyToExistingBranchIn{
-			Files:           files,
-			Repository:      out.Repository,
-			CommitMessage:   in.CommitMessage,
-			BranchName:      out.DefaultBranchName,
-			ParentCommitSHA: out.DefaultBranchCommitSHA,
-			ParentTreeSHA:   out.DefaultBranchTreeSHA,
-			DryRun:          in.DryRun,
-		}); err != nil {
-			return errors.WithStack(err)
-		}
-		return nil
-	}
-
-	if out.BranchCommitSHA == "" || out.BranchTreeSHA == "" {
-		return errors.Errorf("branch %s does not exist", in.BranchName)
-	}
-	if err := u.copyToExistingBranch(ctx, copyToExistingBranchIn{
-		Files:           files,
-		Repository:      out.Repository,
-		CommitMessage:   in.CommitMessage,
-		BranchName:      in.BranchName,
-		ParentCommitSHA: out.BranchCommitSHA,
-		ParentTreeSHA:   out.BranchTreeSHA,
-		DryRun:          in.DryRun,
-	}); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
-
-type copyToExistingBranchIn struct {
-	Files           []adaptors.File
-	Repository      git.RepositoryID
-	CommitMessage   git.CommitMessage
-	BranchName      git.BranchName
-	ParentCommitSHA git.CommitSHA
-	ParentTreeSHA   git.TreeSHA
-	DryRun          bool
-}
-
-func (u *CopyUseCase) copyToExistingBranch(ctx context.Context, in copyToExistingBranchIn) error {
-	gitFiles := make([]git.File, len(in.Files))
-	for i, file := range in.Files {
+	gitFiles := make([]git.File, len(files))
+	for i, file := range files {
 		content, err := u.FileSystem.ReadAsBase64EncodedContent(file.Path)
 		if err != nil {
 			return errors.Wrapf(err, "error while reading file %s", file.Path)
@@ -95,18 +51,61 @@ func (u *CopyUseCase) copyToExistingBranch(ctx context.Context, in copyToExistin
 		if err != nil {
 			return errors.Wrapf(err, "error while creating a blob for %s", file.Path)
 		}
-		gitFiles[i] = git.File{
+		gitFile := git.File{
 			Filename:   file.Path,
 			BlobSHA:    blobSHA,
-			Executable: file.Executable,
+			Executable: !in.NoFileMode && file.Executable,
 		}
+		gitFiles[i] = gitFile
 		u.Logger.Infof("Uploaded %s as blob %s", file.Path, blobSHA)
 	}
 
+	if in.BranchName == "" {
+		// copy to the default branch
+		if err := u.copyToExistingBranch(ctx, copyToExistingBranchIn{
+			CopyUseCaseIn:   in,
+			Files:           gitFiles,
+			Repository:      out.Repository,
+			BranchName:      out.DefaultBranchName,
+			ParentCommitSHA: out.DefaultBranchCommitSHA,
+			ParentTreeSHA:   out.DefaultBranchTreeSHA,
+		}); err != nil {
+			return errors.WithStack(err)
+		}
+		return nil
+	}
+
+	if out.BranchCommitSHA == "" || out.BranchTreeSHA == "" {
+		return errors.Errorf("branch %s does not exist", in.BranchName)
+	}
+	if err := u.copyToExistingBranch(ctx, copyToExistingBranchIn{
+		CopyUseCaseIn:   in,
+		Files:           gitFiles,
+		Repository:      out.Repository,
+		BranchName:      in.BranchName,
+		ParentCommitSHA: out.BranchCommitSHA,
+		ParentTreeSHA:   out.BranchTreeSHA,
+	}); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+type copyToExistingBranchIn struct {
+	usecases.CopyUseCaseIn
+
+	Files           []git.File
+	Repository      git.RepositoryID
+	BranchName      git.BranchName
+	ParentCommitSHA git.CommitSHA
+	ParentTreeSHA   git.TreeSHA
+}
+
+func (u *CopyUseCase) copyToExistingBranch(ctx context.Context, in copyToExistingBranchIn) error {
 	treeSHA, err := u.GitHub.CreateTree(ctx, git.NewTree{
 		Repository:  in.Repository,
 		BaseTreeSHA: in.ParentTreeSHA,
-		Files:       gitFiles,
+		Files:       in.Files,
 	})
 	if err != nil {
 		return errors.Wrapf(err, "error while creating a tree")

--- a/usecases/copy_test.go
+++ b/usecases/copy_test.go
@@ -15,7 +15,10 @@ func newMockFileSystem(ctrl *gomock.Controller) adaptors.FileSystem {
 	fileSystem := mock_adaptors.NewMockFileSystem(ctrl)
 	fileSystem.EXPECT().
 		FindFiles([]string{"path"}).
-		Return([]string{"file1", "file2"}, nil)
+		Return([]adaptors.File{
+			{Path: "file1"},
+			{Path: "file2", Executable: true},
+		}, nil)
 	fileSystem.EXPECT().
 		ReadAsBase64EncodedContent("file1").
 		Return("base64content1", nil)
@@ -31,13 +34,13 @@ func gitHubCreateBlobTree(gitHub *mock_adaptors.MockGitHub, ctx context.Context,
 			Repository: repositoryID,
 			Content:    "base64content1",
 		}).
-		Return(git.BlobSHA("blobSHA"), nil)
+		Return(git.BlobSHA("blobSHA1"), nil)
 	gitHub.EXPECT().
 		CreateBlob(ctx, git.NewBlob{
 			Repository: repositoryID,
 			Content:    "base64content2",
 		}).
-		Return(git.BlobSHA("blobSHA"), nil)
+		Return(git.BlobSHA("blobSHA2"), nil)
 	gitHub.EXPECT().
 		CreateTree(ctx, git.NewTree{
 			Repository:  repositoryID,
@@ -45,10 +48,11 @@ func gitHubCreateBlobTree(gitHub *mock_adaptors.MockGitHub, ctx context.Context,
 			Files: []git.File{
 				{
 					Filename: "file1",
-					BlobSHA:  "blobSHA",
+					BlobSHA:  "blobSHA1",
 				}, {
-					Filename: "file2",
-					BlobSHA:  "blobSHA",
+					Filename:   "file2",
+					BlobSHA:    "blobSHA2",
+					Executable: true,
 				},
 			},
 		}).

--- a/usecases/interfaces/usecases.go
+++ b/usecases/interfaces/usecases.go
@@ -17,5 +17,6 @@ type CopyUseCaseIn struct {
 	CommitMessage git.CommitMessage
 	BranchName    git.BranchName // default branch if empty
 	Paths         []string
+	NoFileMode    bool
 	DryRun        bool
 }


### PR DESCRIPTION
This allows to commit a file with the executable bit. It also adds `--no-file-mode` option for non-unix systems.