### PR TITLE
Improve logs for better user experience

### DIFF
--- a/adaptors/cmd.go
+++ b/adaptors/cmd.go
@@ -80,6 +80,7 @@ func (c *Cmd) Run(ctx context.Context, args []string) int {
 
 	if o.Debug {
 		c.LoggerConfig.SetDebug(true)
+		c.Logger.Debugf("Debug enabled")
 	}
 	if o.Chdir != "" {
 		if err := c.Env.Chdir(o.Chdir); err != nil {
@@ -89,10 +90,11 @@ func (c *Cmd) Run(ctx context.Context, args []string) int {
 		c.Logger.Infof("Changed to directory %s", o.Chdir)
 	}
 	if o.GitHubToken == "" {
+		c.Logger.Debugf("Using token from environment variable %s", envGitHubToken)
 		o.GitHubToken = c.Env.Getenv(envGitHubToken)
 	}
 	if o.GitHubToken == "" {
-		c.Logger.Errorf("No GitHub API token. Set $%s or -token", envGitHubToken)
+		c.Logger.Errorf("No GitHub API token. Set environment variable %s or --token option", envGitHubToken)
 		return exitCodePreconditionError
 	}
 	c.GitHubClientInit.Init(infrastructure.GitHubClientInitOptions{
@@ -119,6 +121,7 @@ func (c *Cmd) copy(ctx context.Context, o copyOptions) int {
 		DryRun:        o.DryRun,
 	}); err != nil {
 		c.Logger.Errorf("Could not copy files: %s", err)
+		c.Logger.Debugf("Stacktrace:\n%+v", err)
 		return exitCodeCopyError
 	}
 	return exitCodeOK


### PR DESCRIPTION
e.g.
```
2019/03/11 14:35:01 INFO  Author and committer: int128
2019/03/11 14:35:01 INFO  Copying 1 file(s) to the master branch
2019/03/11 14:35:02 INFO  Uploaded LICENSE as blob 261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64
2019/03/11 14:35:02 INFO  Created tree 2b2b711266cd916c7c1e2233aec80aec6d652a3d
2019/03/11 14:35:03 INFO  Created commit e875174c8be334bb6ddeede4f76b6f0fd295ee60
2019/03/11 14:35:03 INFO  Commit: 0 changed file(s)
2019/03/11 14:35:03 WARN  Nothing to commit because master branch has the same file(s)
```

```
2019/03/11 14:40:16 DEBUG Debug enabled
2019/03/11 14:40:16 DEBUG Using token from environment variable GITHUB_TOKEN
2019/03/11 14:40:16 DEBUG Querying the repository with map[ref: owner:int128 repo:sandbox]
2019/03/11 14:40:17 DEBUG Got the result: {Viewer:{Login:int128} Repository:{Name:sandbox Owner:{Login:int128} DefaultBranchRef:{Name:master Target:{Commit:{Oid:30170d4178c22a6fa30d9794e4f8c829b18fc6fd Tree:{Oid:2b2b711266cd916c7c1e2233aec80aec6d652a3d}}}} Ref:{Target:{Commit:{Oid: Tree:{Oid:}}}}}}
2019/03/11 14:40:17 DEBUG Returning the repository: {CurrentUserName:int128 Repository:{Owner:int128 Name:sandbox} DefaultBranchName:master DefaultBranchCommitSHA:30170d4178c22a6fa30d9794e4f8c829b18fc6fd DefaultBranchTreeSHA:2b2b711266cd916c7c1e2233aec80aec6d652a3d BranchCommitSHA: BranchTreeSHA:}
2019/03/11 14:40:17 INFO  Author and committer: int128
2019/03/11 14:40:17 INFO  Copying 1 file(s) to master branch
2019/03/11 14:40:17 DEBUG Creating a blob of 15144 byte(s) on the repository {Owner:int128 Name:sandbox}
2019/03/11 14:40:18 INFO  Uploaded LICENSE as blob 261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64
2019/03/11 14:40:18 DEBUG Creating a tree {Repository:{Owner:int128 Name:sandbox} BaseTreeSHA:2b2b711266cd916c7c1e2233aec80aec6d652a3d Files:[{Filename:LICENSE BlobSHA:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64 Executable:false}]}
2019/03/11 14:40:18 INFO  Created tree 2b2b711266cd916c7c1e2233aec80aec6d652a3d
2019/03/11 14:40:18 DEBUG Creating a commit {Repository:{Owner:int128 Name:sandbox} Message:example commit ParentCommitSHA:30170d4178c22a6fa30d9794e4f8c829b18fc6fd TreeSHA:2b2b711266cd916c7c1e2233aec80aec6d652a3d}
2019/03/11 14:40:19 INFO  Created commit 7f41add9b06441609f79830d76c535cbb51b0b14
2019/03/11 14:40:19 DEBUG Querying the commit with map[repo:sandbox commitSHA:7f41add9b06441609f79830d76c535cbb51b0b14 owner:int128]
2019/03/11 14:40:20 DEBUG Got the result: {Repository:{Object:{Commit:{ChangedFiles:0}}}}
2019/03/11 14:40:20 DEBUG Returning the commit: {ChangedFiles:0}
2019/03/11 14:40:20 INFO  Commit: 0 changed file(s)
2019/03/11 14:40:20 WARN  Nothing to commit because master branch has the same file(s)
```