### PR TITLE
Add feature to create a commit without any parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ Options:
   -m, --message string      Commit message (mandatory)
   -B, --new-branch string   Create a branch
       --no-file-mode        Ignore executable bit of file and treat as 0644
+      --no-parent           Create a commit without a parent
   -u, --owner string        GitHub repository owner (mandatory)
-      --parent string       Parent branch or tag (default: default branch of repository)
+      --parent string       Create a commit from the parent branch or tag (default: default branch of repository)
   -r, --repo string         GitHub repository name (mandatory)
       --token string        GitHub API token [$GITHUB_TOKEN]
 ```
@@ -89,6 +90,12 @@ To copy files to the `gh-pages` branch:
 
 ```sh
 ghcp -u YOUR -r REPO -b gh-pages -m MESSAGE index.html
+```
+
+If you want to discard history of the past commits:
+
+```sh
+ghcp -u YOUR -r REPO -b gh-pages --no-parent -m MESSAGE index.html
 ```
 
 ### Release to Homebrew tap

--- a/adaptors/github.go
+++ b/adaptors/github.go
@@ -215,9 +215,13 @@ func (c *GitHub) QueryCommit(ctx context.Context, in adaptors.QueryCommitIn) (*a
 // CreateCommit creates a commit and returns SHA of it.
 func (c *GitHub) CreateCommit(ctx context.Context, n git.NewCommit) (git.CommitSHA, error) {
 	c.Logger.Debugf("Creating a commit %+v", n)
+	var parents []github.Commit
+	if n.ParentCommitSHA != "" {
+		parents = append(parents, github.Commit{SHA: github.String(string(n.ParentCommitSHA))})
+	}
 	commit, _, err := c.Client.CreateCommit(ctx, n.Repository.Owner, n.Repository.Name, &github.Commit{
 		Message: github.String(string(n.Message)),
-		Parents: []github.Commit{{SHA: github.String(string(n.ParentCommitSHA))}},
+		Parents: parents,
 		Tree:    &github.Tree{SHA: github.String(string(n.TreeSHA))},
 	})
 	if err != nil {

--- a/adaptors/github_test.go
+++ b/adaptors/github_test.go
@@ -1,0 +1,79 @@
+package adaptors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-github/v24/github"
+	"github.com/int128/ghcp/adaptors/mock_adaptors"
+	"github.com/int128/ghcp/git"
+	"github.com/int128/ghcp/infrastructure/mock_infrastructure"
+)
+
+func TestGitHub_CreateCommit(t *testing.T) {
+	ctx := context.TODO()
+	repositoryID := git.RepositoryID{Owner: "owner", Name: "repo"}
+
+	t.Run("SingleParent", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		gitHubClient := mock_infrastructure.NewMockGitHubClient(ctrl)
+		gitHubClient.EXPECT().
+			CreateCommit(ctx, "owner", "repo", &github.Commit{
+				Message: github.String("message"),
+				Parents: []github.Commit{{SHA: github.String("parentCommitSHA")}},
+				Tree:    &github.Tree{SHA: github.String("treeSHA")},
+			}).
+			Return(&github.Commit{
+				SHA: github.String("commitSHA"),
+			}, nil, nil)
+		gitHub := GitHub{
+			Client: gitHubClient,
+			Logger: mock_adaptors.NewLogger(t),
+		}
+		commitSHA, err := gitHub.CreateCommit(ctx, git.NewCommit{
+			Repository:      repositoryID,
+			Message:         "message",
+			ParentCommitSHA: "parentCommitSHA",
+			TreeSHA:         "treeSHA",
+		})
+		if err != nil {
+			t.Fatalf("CreateCommit returned error: %+v", err)
+		}
+		if commitSHA != "commitSHA" {
+			t.Errorf("commitSHA wants commitSHA but %s", commitSHA)
+		}
+	})
+
+	t.Run("NoParent", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		gitHubClient := mock_infrastructure.NewMockGitHubClient(ctrl)
+		gitHubClient.EXPECT().
+			CreateCommit(ctx, "owner", "repo", &github.Commit{
+				Message: github.String("message"),
+				Tree:    &github.Tree{SHA: github.String("treeSHA")},
+			}).
+			Return(&github.Commit{
+				SHA: github.String("commitSHA"),
+			}, nil, nil)
+		gitHub := GitHub{
+			Client: gitHubClient,
+			Logger: mock_adaptors.NewLogger(t),
+		}
+		commitSHA, err := gitHub.CreateCommit(ctx, git.NewCommit{
+			Repository: repositoryID,
+			Message:    "message",
+			TreeSHA:    "treeSHA",
+		})
+		if err != nil {
+			t.Fatalf("CreateCommit returned error: %+v", err)
+		}
+		if commitSHA != "commitSHA" {
+			t.Errorf("commitSHA wants commitSHA but %s", commitSHA)
+		}
+	})
+}

--- a/usecases/create_branch_test.go
+++ b/usecases/create_branch_test.go
@@ -86,12 +86,13 @@ func TestCreateBranch_Do(t *testing.T) {
 				GitHub:     gitHub,
 			}
 			err := useCase.Do(ctx, usecases.CreateBranchIn{
-				Repository:    repositoryID,
-				NewBranchName: "topic",
-				CommitMessage: "message",
-				Paths:         []string{"path"},
-				NoFileMode:    c.NoFileMode,
-				DryRun:        c.DryRun,
+				Repository:        repositoryID,
+				NewBranchName:     "topic",
+				ParentOfNewBranch: usecases.ParentOfNewBranch{FromDefaultBranch: true},
+				CommitMessage:     "message",
+				Paths:             []string{"path"},
+				NoFileMode:        c.NoFileMode,
+				DryRun:            c.DryRun,
 			})
 			if err != nil {
 				t.Errorf("Do returned error: %+v", err)
@@ -167,13 +168,92 @@ func TestCreateBranch_Do(t *testing.T) {
 				GitHub:     gitHub,
 			}
 			err := useCase.Do(ctx, usecases.CreateBranchIn{
-				Repository:    repositoryID,
-				NewBranchName: "topic",
-				ParentRef:     "develop",
-				CommitMessage: "message",
-				Paths:         []string{"path"},
-				NoFileMode:    c.NoFileMode,
-				DryRun:        c.DryRun,
+				Repository:        repositoryID,
+				NewBranchName:     "topic",
+				ParentOfNewBranch: usecases.ParentOfNewBranch{FromRef: "develop"},
+				CommitMessage:     "message",
+				Paths:             []string{"path"},
+				NoFileMode:        c.NoFileMode,
+				DryRun:            c.DryRun,
+			})
+			if err != nil {
+				t.Errorf("Do returned error: %+v", err)
+			}
+		})
+
+		t.Run("NoParent", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			fileSystem := mock_adaptors.NewMockFileSystem(ctrl)
+			fileSystem.EXPECT().
+				FindFiles([]string{"path"}).
+				Return([]adaptors.File{
+					{Path: "file1"},
+					{Path: "file2", Executable: true},
+				}, nil)
+
+			commitUseCase := mock_usecases.NewMockCommit(ctrl)
+			commitUseCase.EXPECT().
+				Do(ctx, usecases.CommitIn{
+					Files: []adaptors.File{
+						{Path: "file1"},
+						{Path: "file2", Executable: true},
+					},
+					Repository:    repositoryID,
+					CommitMessage: "message",
+					NoFileMode:    c.NoFileMode,
+				}).
+				Return(&usecases.CommitOut{
+					CommitSHA:    "commitSHA",
+					ChangedFiles: c.ChangedFiles,
+				}, nil)
+
+			gitHub := mock_adaptors.NewMockGitHub(ctrl)
+			gitHub.EXPECT().
+				QueryForCreateBranch(ctx, adaptors.QueryForCreateBranchIn{
+					Repository:    repositoryID,
+					NewBranchName: "gh-pages",
+				}).
+				Return(&adaptors.QueryForCreateBranchOut{
+					CurrentUserName: "current",
+					Repository:      repositoryID,
+					DefaultBranchRefName: git.RefQualifiedName{
+						Prefix: "refs/heads/",
+						Name:   "master",
+					},
+					DefaultBranchCommitSHA: "masterCommitSHA",
+					DefaultBranchTreeSHA:   "masterTreeSHA",
+					ParentRefName: git.RefQualifiedName{
+						Prefix: "refs/heads/",
+						Name:   "gh-pages",
+					},
+					ParentRefCommitSHA: "ghCommitSHA",
+					ParentRefTreeSHA:   "ghTreeSHA",
+				}, nil)
+			gitHub.EXPECT().
+				CreateBranch(ctx, git.NewBranch{
+					Repository: repositoryID,
+					BranchName: "gh-pages",
+					CommitSHA:  "commitSHA",
+				}).
+				Return(nil).
+				Times(c.CreateBranchTimes)
+
+			useCase := CreateBranch{
+				Commit:     commitUseCase,
+				FileSystem: fileSystem,
+				Logger:     mock_adaptors.NewLogger(t),
+				GitHub:     gitHub,
+			}
+			err := useCase.Do(ctx, usecases.CreateBranchIn{
+				Repository:        repositoryID,
+				NewBranchName:     "gh-pages",
+				ParentOfNewBranch: usecases.ParentOfNewBranch{NoParent: true},
+				CommitMessage:     "message",
+				Paths:             []string{"path"},
+				NoFileMode:        c.NoFileMode,
+				DryRun:            c.DryRun,
 			})
 			if err != nil {
 				t.Errorf("Do returned error: %+v", err)

--- a/usecases/interfaces/usecases.go
+++ b/usecases/interfaces/usecases.go
@@ -27,13 +27,21 @@ type CreateBranch interface {
 }
 
 type CreateBranchIn struct {
-	Repository    git.RepositoryID
-	NewBranchName git.BranchName
-	ParentRef     git.RefName // default branch if empty
-	CommitMessage git.CommitMessage
-	Paths         []string
-	NoFileMode    bool
-	DryRun        bool
+	Repository        git.RepositoryID
+	NewBranchName     git.BranchName
+	ParentOfNewBranch ParentOfNewBranch
+	CommitMessage     git.CommitMessage
+	Paths             []string
+	NoFileMode        bool
+	DryRun            bool
+}
+
+// ParentOfNewBranch represents a parent of a branch to create.
+// Exact one of the members must be valid.
+type ParentOfNewBranch struct {
+	NoParent          bool
+	FromDefaultBranch bool
+	FromRef           git.RefName
 }
 
 type Commit interface {
@@ -44,8 +52,8 @@ type CommitIn struct {
 	Files           []adaptors.File
 	Repository      git.RepositoryID
 	CommitMessage   git.CommitMessage
-	ParentCommitSHA git.CommitSHA
-	ParentTreeSHA   git.TreeSHA
+	ParentCommitSHA git.CommitSHA // no parent if empty
+	ParentTreeSHA   git.TreeSHA   // no parent if empty
 	NoFileMode      bool
 }
 


### PR DESCRIPTION
This adds the feature to create a commit without any parent. It is useful for updating static assets such as GitHub Pages.