### PR TITLE
support go 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,13 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13.5
     steps:
       - run: |
           mkdir -p ~/bin
           echo 'export PATH="$HOME/bin:$PATH"' >> $BASH_ENV
       - run: |
-          curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ~/bin v1.17.1
+          curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ~/bin v1.21.0
       - run: go get github.com/mitchellh/gox
       - run: go get github.com/tcnksm/ghr
       - checkout

--- a/adaptors/github/github.go
+++ b/adaptors/github/github.go
@@ -29,11 +29,10 @@ type GitHub struct {
 func (c *GitHub) CreateFork(ctx context.Context, id git.RepositoryID) (*git.RepositoryID, error) {
 	fork, _, err := c.Client.CreateFork(ctx, id.Owner, id.Name, nil)
 	if err != nil {
-		if _, ok := err.(*github.AcceptedError); ok {
-			c.Logger.Debugf("Fork in progress: %+v", err)
-		} else {
+		if _, ok := err.(*github.AcceptedError); !ok {
 			return nil, xerrors.Errorf("GitHub API error: %w", err)
 		}
+		c.Logger.Debugf("Fork in progress: %+v", err)
 	}
 	forkRepository := git.RepositoryID{
 		Owner: fork.GetOwner().GetLogin(),

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,7 @@ require (
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
 	github.com/spf13/cobra v0.0.5
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
-	golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190422233926-fe54fb35175b/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
-golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=


### PR DESCRIPTION
I want to need it can be built on go 1.13. Because I will be used in my project this package as the library.
But when I try to build, it had a few errors.
So I fixed it as possible to build on go 1.13. 

* update golang.orx/x/xerrors. The current version has problems on go 1.13. https://github.com/golang/go/issues/32246
* fix type asserting.
  * The current code is valid in golang. But an error occur on golangci-lint@latest. 
  * golangci-lint v1.17.1(use in CircleCI) is not supported go 1.13.
  * In golangci-lint v1.21.0(latest), an error occur `adaptors/github/github.go:32:3: S1020: when ok is true, err can't be nil (gosimple)`
  * I fix to use early return.