### PR TITLE
WIP: Move to v4 mutation

### DIFF
--- a/domain/git/git.go
+++ b/domain/git/git.go
@@ -1,10 +1,15 @@
 // Package git provides the models of Git such as a repository and branch.
 package git
 
+// InternalNodeID represents a node ID for GitHub v4 API.
+// This is allocated by GitHub.
+type InternalNodeID interface{}
+
 // RepositoryID represents a pointer to a repository.
 type RepositoryID struct {
-	Owner string
-	Name  string
+	Owner          string
+	Name           string
+	InternalNodeID InternalNodeID
 }
 
 // IsValid returns true if owner and name is not empty.

--- a/infrastructure/github/github.go
+++ b/infrastructure/github/github.go
@@ -29,6 +29,7 @@ type Interface interface {
 
 type QueryService interface {
 	Query(ctx context.Context, q interface{}, variables map[string]interface{}) error
+	Mutate(ctx context.Context, m interface{}, input githubv4.Input, variables map[string]interface{}) error
 }
 
 type GitService interface {


### PR DESCRIPTION
DO NOT MERGE THIS PR.

This will move creating/updating operations to the v4 mutation API. For now the following mutations are available.

- https://developer.github.com/v4/mutation/createref/
- https://developer.github.com/v4/mutation/updateref/

It needs to hold a node ID in each model such as a repository and ref. Currently we identify an entity using a natural key, e.g. a pair of repository owner and name and need to use a node ID.

For now I do not investigate more but will try it if v4 supports mutation of the Git objects such as commit, tree and blob.

See also:
- https://github.com/shurcooL/githubv4#mutations
