### PR TITLE
Reduce conditional cases on commit use-case

### DIFF
--- a/adaptors/github/commit.go
+++ b/adaptors/github/commit.go
@@ -81,8 +81,6 @@ type QueryForCommitOutput struct {
 	ParentDefaultBranchTreeSHA   git.TreeSHA
 	ParentRefCommitSHA           git.CommitSHA // empty if the parent ref does not exist
 	ParentRefTreeSHA             git.TreeSHA   // empty if the parent ref does not exist
-	TargetRepository             git.RepositoryID
-	TargetDefaultBranchName      git.BranchName
 	TargetBranchCommitSHA        git.CommitSHA // empty if the branch does not exist
 	TargetBranchTreeSHA          git.TreeSHA   // empty if the branch does not exist
 }
@@ -128,15 +126,6 @@ func (c *GitHub) QueryForCommit(ctx context.Context, in QueryForCommitInput) (*Q
 		} `graphql:"parentRepository: repository(owner: $parentOwner, name: $parentRepo)"`
 
 		TargetRepository struct {
-			Name  string
-			Owner struct{ Login string }
-
-			// default branch
-			DefaultBranchRef struct {
-				Name string
-			}
-
-			// branch (optional)
 			Ref struct {
 				Target struct {
 					Commit struct {
@@ -168,8 +157,6 @@ func (c *GitHub) QueryForCommit(ctx context.Context, in QueryForCommitInput) (*Q
 		ParentDefaultBranchTreeSHA:   git.TreeSHA(q.ParentRepository.DefaultBranchRef.Target.Commit.Tree.Oid),
 		ParentRefCommitSHA:           git.CommitSHA(q.ParentRepository.ParentRef.Target.Commit.Oid),
 		ParentRefTreeSHA:             git.TreeSHA(q.ParentRepository.ParentRef.Target.Commit.Tree.Oid),
-		TargetRepository:             git.RepositoryID{Owner: q.TargetRepository.Owner.Login, Name: q.TargetRepository.Name},
-		TargetDefaultBranchName:      git.BranchName(q.TargetRepository.DefaultBranchRef.Name),
 		TargetBranchCommitSHA:        git.CommitSHA(q.TargetRepository.Ref.Target.Commit.Oid),
 		TargetBranchTreeSHA:          git.TreeSHA(q.TargetRepository.Ref.Target.Commit.Tree.Oid),
 	}

--- a/adaptors/github/github.go
+++ b/adaptors/github/github.go
@@ -51,8 +51,8 @@ type QueryDefaultBranchOutput struct {
 // QueryDefaultBranch returns the default branch names.
 // You can set both repositories or either repository.
 func (c *GitHub) QueryDefaultBranch(ctx context.Context, in QueryDefaultBranchInput) (*QueryDefaultBranchOutput, error) {
-	if !in.BaseRepository.IsValid() && !in.HeadRepository.IsValid() {
-		return nil, xerrors.New("BaseRepository and HeadRepository are zero")
+	if !in.BaseRepository.IsValid() || !in.HeadRepository.IsValid() {
+		return nil, xerrors.New("you need to set both BaseRepository and HeadRepository")
 	}
 	var q struct {
 		BaseRepository struct {

--- a/usecases/commit/commit.go
+++ b/usecases/commit/commit.go
@@ -35,6 +35,8 @@ type Input struct {
 	Paths            []string
 	NoFileMode       bool
 	DryRun           bool
+
+	ForceUpdate bool //TODO: support force-update as well
 }
 
 // Commit commits files to the default/given branch on the repository.
@@ -65,9 +67,36 @@ func (u *Commit) Do(ctx context.Context, in Input) error {
 	}
 
 	if in.TargetBranchName == "" {
-		return u.commitDefaultBranch(ctx, in, files)
+		q, err := u.GitHub.QueryDefaultBranch(ctx, github.QueryDefaultBranchInput{
+			HeadRepository: in.TargetRepository,
+			BaseRepository: in.ParentRepository, // mandatory but not used
+		})
+		if err != nil {
+			return xerrors.Errorf("could not determine the default branch: %w", err)
+		}
+		in.TargetBranchName = q.HeadDefaultBranchName
 	}
-	return u.commitTargetBranch(ctx, in, files)
+
+	q, err := u.GitHub.QueryForCommit(ctx, github.QueryForCommitInput{
+		ParentRepository: in.ParentRepository,
+		ParentRef:        in.CommitStrategy.RebaseUpstream(), // valid only if rebase
+		TargetRepository: in.TargetRepository,
+		TargetBranchName: in.TargetBranchName,
+	})
+	if err != nil {
+		return xerrors.Errorf("could not find the repository: %w", err)
+	}
+	u.Logger.Infof("Author and committer: %s", q.CurrentUserName)
+	if q.TargetBranchExists() {
+		if err := u.updateExistingBranch(ctx, in, files, q); err != nil {
+			return xerrors.Errorf("could not update the existing branch (%s): %w", in.TargetBranchName, err)
+		}
+		return nil
+	}
+	if err := u.createNewBranch(ctx, in, files, q); err != nil {
+		return xerrors.Errorf("could not create a branch (%s) based on the default branch: %w", in.TargetBranchName, err)
+	}
+	return nil
 }
 
 type pathFilter struct {
@@ -87,130 +116,30 @@ func (f *pathFilter) ExcludeFile(string) bool {
 	return false
 }
 
-func (u *Commit) commitDefaultBranch(ctx context.Context, in Input, files []fs.File) error {
-	q, err := u.GitHub.QueryForCommit(ctx, github.QueryForCommitInput{
-		ParentRepository: in.ParentRepository,
-		ParentRef:        in.CommitStrategy.RebaseUpstream(), // valid only if rebase
-		TargetRepository: in.TargetRepository,
-	})
-	if err != nil {
-		return xerrors.Errorf("could not find the repository: %w", err)
-	}
-	u.Logger.Infof("Author and committer: %s", q.CurrentUserName)
-
-	bi := updateBranchInput{
-		Input: gitobject.Input{
-			Files:         files,
-			Repository:    q.TargetRepository,
-			CommitMessage: in.CommitMessage,
-			NoFileMode:    in.NoFileMode,
-		},
-		BranchName: q.TargetDefaultBranchName,
-		DryRun:     in.DryRun,
+func (u *Commit) createNewBranch(ctx context.Context, in Input, files []fs.File, q *github.QueryForCommitOutput) error {
+	gitObj := gitobject.Input{
+		Files:         files,
+		Repository:    in.TargetRepository,
+		CommitMessage: in.CommitMessage,
+		NoFileMode:    in.NoFileMode,
 	}
 	switch {
 	case in.CommitStrategy.IsFastForward():
-		u.Logger.Debugf("Updating the default branch by fast-forward")
-		bi.ParentCommitSHA = q.ParentDefaultBranchCommitSHA
-		bi.ParentTreeSHA = q.ParentDefaultBranchTreeSHA
+		u.Logger.Infof("Creating a branch (%s) based on the default branch", in.TargetBranchName)
+		gitObj.ParentCommitSHA = q.ParentDefaultBranchCommitSHA
+		gitObj.ParentTreeSHA = q.ParentDefaultBranchTreeSHA
 	case in.CommitStrategy.IsRebase():
-		u.Logger.Debugf("Rebasing the default branch on the ref (%s)", in.CommitStrategy.RebaseUpstream())
-		bi.ParentCommitSHA = q.ParentRefCommitSHA
-		bi.ParentTreeSHA = q.ParentRefTreeSHA
+		u.Logger.Infof("Creating a branch (%s) based on the ref (%s)", in.TargetBranchName, in.CommitStrategy.RebaseUpstream())
+		gitObj.ParentCommitSHA = q.ParentRefCommitSHA
+		gitObj.ParentTreeSHA = q.ParentRefTreeSHA
 	case in.CommitStrategy.NoParent():
-		u.Logger.Debugf("Updating the default branch to a commit with no parent")
+		u.Logger.Infof("Creating a branch (%s) with no parent", in.TargetBranchName)
 	default:
 		return xerrors.Errorf("unknown commit strategy %+v", in.CommitStrategy)
 	}
-	if err := u.updateBranch(ctx, bi); err != nil {
-		return xerrors.Errorf("could not update the default branch: %w", err)
-	}
-	return nil
-}
 
-func (u *Commit) commitTargetBranch(ctx context.Context, in Input, files []fs.File) error {
-	q, err := u.GitHub.QueryForCommit(ctx, github.QueryForCommitInput{
-		ParentRepository: in.ParentRepository,
-		ParentRef:        in.CommitStrategy.RebaseUpstream(), // valid only if rebase
-		TargetRepository: in.TargetRepository,
-		TargetBranchName: in.TargetBranchName,
-	})
-	if err != nil {
-		return xerrors.Errorf("could not find the repository: %w", err)
-	}
-	u.Logger.Infof("Author and committer: %s", q.CurrentUserName)
-
-	if q.TargetBranchExists() {
-		bi := updateBranchInput{
-			Input: gitobject.Input{
-				Files:         files,
-				Repository:    q.TargetRepository,
-				CommitMessage: in.CommitMessage,
-				NoFileMode:    in.NoFileMode,
-			},
-			BranchName: in.TargetBranchName,
-			DryRun:     in.DryRun,
-		}
-		switch {
-		case in.CommitStrategy.IsFastForward():
-			u.Logger.Debugf("Updating the branch (%s) by fast-forward", in.TargetBranchName)
-			bi.ParentCommitSHA = q.TargetBranchCommitSHA
-			bi.ParentTreeSHA = q.TargetBranchTreeSHA
-		case in.CommitStrategy.IsRebase():
-			u.Logger.Debugf("Rebasing the branch (%s) on the ref (%s)", in.TargetBranchName, in.CommitStrategy.RebaseUpstream())
-			bi.ParentCommitSHA = q.ParentRefCommitSHA
-			bi.ParentTreeSHA = q.ParentRefTreeSHA
-		case in.CommitStrategy.NoParent():
-			u.Logger.Debugf("Updating the branch (%s) to a commit with no parent", in.TargetBranchName)
-		default:
-			return xerrors.Errorf("unknown commit strategy %+v", in.CommitStrategy)
-		}
-		if err := u.updateBranch(ctx, bi); err != nil {
-			return xerrors.Errorf("could not update the branch (%s) by fast-forward: %w", in.TargetBranchName, err)
-		}
-		return nil
-	}
-
-	bi := createBranchInput{
-		Input: gitobject.Input{
-			Files:         files,
-			Repository:    q.TargetRepository,
-			CommitMessage: in.CommitMessage,
-			NoFileMode:    in.NoFileMode,
-		},
-		NewBranchName: in.TargetBranchName,
-		DryRun:        in.DryRun,
-	}
-	switch {
-	case in.CommitStrategy.IsFastForward():
-		u.Logger.Debugf("Creating a branch (%s) based on the default branch", in.TargetBranchName)
-		bi.ParentCommitSHA = q.ParentDefaultBranchCommitSHA
-		bi.ParentTreeSHA = q.ParentDefaultBranchTreeSHA
-	case in.CommitStrategy.IsRebase():
-		u.Logger.Debugf("Creating a branch (%s) based on the ref (%s)", in.TargetBranchName, in.CommitStrategy.RebaseUpstream())
-		bi.ParentCommitSHA = q.ParentRefCommitSHA
-		bi.ParentTreeSHA = q.ParentRefTreeSHA
-	case in.CommitStrategy.NoParent():
-		u.Logger.Debugf("Creating a branch (%s) with no parent", in.TargetBranchName)
-	default:
-		return xerrors.Errorf("unknown commit strategy %+v", in.CommitStrategy)
-	}
-	if err := u.createBranch(ctx, bi); err != nil {
-		return xerrors.Errorf("could not create a branch (%s) based on the default branch: %w", in.TargetBranchName, err)
-	}
-	return nil
-}
-
-type createBranchInput struct {
-	gitobject.Input
-
-	NewBranchName git.BranchName
-	DryRun        bool
-}
-
-func (u *Commit) createBranch(ctx context.Context, in createBranchInput) error {
-	u.Logger.Debugf("Creating a commit with the %d file(s)", len(in.Files))
-	commit, err := u.CreateGitObject.Do(ctx, in.Input)
+	u.Logger.Debugf("Creating a commit with the %d file(s)", len(gitObj.Files))
+	commit, err := u.CreateGitObject.Do(ctx, gitObj)
 	if err != nil {
 		return xerrors.Errorf("error while creating a commit: %w", err)
 	}
@@ -220,54 +149,67 @@ func (u *Commit) createBranch(ctx context.Context, in createBranchInput) error {
 		return nil
 	}
 	if in.DryRun {
-		u.Logger.Infof("Do not create %s branch due to dry-run", in.NewBranchName)
+		u.Logger.Infof("Do not create %s branch due to dry-run", in.TargetBranchName)
 		return nil
 	}
 
-	u.Logger.Debugf("Creating a branch (%s)", in.NewBranchName)
+	u.Logger.Debugf("Creating a branch (%s)", in.TargetBranchName)
 	if err := u.GitHub.CreateBranch(ctx, git.NewBranch{
-		Repository: in.Repository,
-		BranchName: in.NewBranchName,
+		Repository: in.TargetRepository,
+		BranchName: in.TargetBranchName,
 		CommitSHA:  commit.CommitSHA,
 	}); err != nil {
-		return xerrors.Errorf("error while creating %s branch: %w", in.NewBranchName, err)
+		return xerrors.Errorf("error while creating %s branch: %w", in.TargetBranchName, err)
 	}
-	u.Logger.Infof("Created a branch (%s)", in.NewBranchName)
+	u.Logger.Infof("Created a branch (%s)", in.TargetBranchName)
 	return nil
 }
 
-type updateBranchInput struct {
-	gitobject.Input
+func (u *Commit) updateExistingBranch(ctx context.Context, in Input, files []fs.File, q *github.QueryForCommitOutput) error {
+	gitObj := gitobject.Input{
+		Files:         files,
+		Repository:    in.TargetRepository,
+		CommitMessage: in.CommitMessage,
+		NoFileMode:    in.NoFileMode,
+	}
+	switch {
+	case in.CommitStrategy.IsFastForward():
+		u.Logger.Infof("Updating the branch (%s) by fast-forward", in.TargetBranchName)
+		gitObj.ParentCommitSHA = q.TargetBranchCommitSHA
+		gitObj.ParentTreeSHA = q.TargetBranchTreeSHA
+	case in.CommitStrategy.IsRebase():
+		u.Logger.Infof("Rebasing the branch (%s) on the ref (%s)", in.TargetBranchName, in.CommitStrategy.RebaseUpstream())
+		gitObj.ParentCommitSHA = q.ParentRefCommitSHA
+		gitObj.ParentTreeSHA = q.ParentRefTreeSHA
+	case in.CommitStrategy.NoParent():
+		u.Logger.Infof("Updating the branch (%s) to a commit with no parent", in.TargetBranchName)
+	default:
+		return xerrors.Errorf("unknown commit strategy %+v", in.CommitStrategy)
+	}
 
-	BranchName  git.BranchName
-	DryRun      bool
-	ForceUpdate bool
-}
-
-func (u *Commit) updateBranch(ctx context.Context, in updateBranchInput) error {
-	u.Logger.Debugf("Creating a commit with the %d file(s)", len(in.Files))
-	commit, err := u.CreateGitObject.Do(ctx, in.Input)
+	u.Logger.Debugf("Creating a commit with the %d file(s)", len(gitObj.Files))
+	commit, err := u.CreateGitObject.Do(ctx, gitObj)
 	if err != nil {
 		return xerrors.Errorf("error while creating a commit: %w", err)
 	}
 	u.Logger.Infof("Created a commit with %d changed file(s)", commit.ChangedFiles)
 	if commit.ChangedFiles == 0 {
-		u.Logger.Warnf("Nothing to commit because %s branch has the same file(s)", in.BranchName)
+		u.Logger.Warnf("Nothing to commit because %s branch has the same file(s)", in.TargetBranchName)
 		return nil
 	}
 	if in.DryRun {
-		u.Logger.Infof("Do not update %s branch due to dry-run", in.BranchName)
+		u.Logger.Infof("Do not update %s branch due to dry-run", in.TargetBranchName)
 		return nil
 	}
 
-	u.Logger.Debugf("Updating the branch (%s)", in.BranchName)
+	u.Logger.Debugf("Updating the branch (%s)", in.TargetBranchName)
 	if err := u.GitHub.UpdateBranch(ctx, git.NewBranch{
-		Repository: in.Repository,
-		BranchName: in.BranchName,
+		Repository: in.TargetRepository,
+		BranchName: in.TargetBranchName,
 		CommitSHA:  commit.CommitSHA,
 	}, in.ForceUpdate); err != nil {
-		return xerrors.Errorf("error while updating %s branch: %w", in.BranchName, err)
+		return xerrors.Errorf("error while updating %s branch: %w", in.TargetBranchName, err)
 	}
-	u.Logger.Infof("Updated the branch (%s)", in.BranchName)
+	u.Logger.Infof("Updated the branch (%s)", in.TargetBranchName)
 	return nil
 }


### PR DESCRIPTION
This will reduce the conditional cases in the commit use-case.

## Design

as-is:

- when the target is the default branch
  - when the target branch exists
    - update the target default branch
  - ~~when the target branch does not exist~~ (not supported)
- when the target is the specific branch
  - when the target branch exists
    - update the target branch
  - when the target branch does not exist
    - create the target branch

to-be:

- resolve the default branch name
- when the target branch exists
  - update the target default branch
- when the target branch does not exist
  - create the target branch

## VS

Pros:

- Easy to understand
- Reduce the test cases

Cons:

- Need 2 queries (currently 1 query)