### PR TITLE
Change logger to show only timestamp

### DIFF
--- a/adaptors/logger/logger.go
+++ b/adaptors/logger/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"log"
+	"os"
 
 	"github.com/google/wire"
 )
@@ -26,27 +27,29 @@ type Option struct {
 }
 
 func New(o Option) Interface {
-	return &logger{opt: o}
+	lgr := log.New(os.Stderr, "", log.Lmicroseconds)
+	return &logger{opt: o, lgr: lgr}
 }
 
 type logger struct {
+	lgr *log.Logger
 	opt Option
 }
 
-func (*logger) Errorf(format string, v ...interface{}) {
-	log.Printf("ERROR "+format, v...)
+func (l *logger) Errorf(format string, v ...interface{}) {
+	l.lgr.Printf("ERROR "+format, v...)
 }
 
-func (*logger) Warnf(format string, v ...interface{}) {
-	log.Printf("WARN  "+format, v...)
+func (l *logger) Warnf(format string, v ...interface{}) {
+	l.lgr.Printf("WARN  "+format, v...)
 }
 
-func (*logger) Infof(format string, v ...interface{}) {
-	log.Printf("INFO  "+format, v...)
+func (l *logger) Infof(format string, v ...interface{}) {
+	l.lgr.Printf("INFO  "+format, v...)
 }
 
 func (l *logger) Debugf(format string, v ...interface{}) {
 	if l.opt.Debug {
-		log.Printf("DEBUG "+format, v...)
+		l.lgr.Printf("DEBUG "+format, v...)
 	}
 }


### PR DESCRIPTION
e.g.:

```
10:17:33.625794 INFO  Author and committer: int128
10:17:33.626194 INFO  Updating the branch (master) by fast-forward
10:17:34.831723 INFO  Uploaded LICENSE as blob 261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64
10:17:35.768458 INFO  Created tree 95a60ea07d96da57c7ecbb1717c0d5e611398288
10:17:36.665063 INFO  Created commit c1fc610ffcff3c4eaa72ff369a648229121c11ce
10:17:37.295778 INFO  Created a commit with 0 changed file(s)
10:17:37.295821 WARN  Nothing to commit because master branch has the same file(s)
```