### PR TITLE
Add release --target option

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,15 +162,25 @@ ghcp release -u OWNER -r REPO -t v1.0.0 dist/
 If the release does not exist, it will create a release.
 If the tag does not exist, it will create a tag from the default branch and create a release.
 
+To create a tag and release on commit `COMMIT_SHA` and upload files to the release:
+
+```sh
+ghcp release -u OWNER -r REPO -t v1.0.0 --target COMMIT_SHA dist/
+```
+
+If the tag already exists, it ignores the target commit.
+If the release already exist, it only uploads the files.
+
 You can set the following options.
 
 ```
 Flags:
-      --dry-run        Do not create a release and assets actually
-  -h, --help           help for release
-  -u, --owner string   GitHub repository owner (mandatory)
-  -r, --repo string    GitHub repository name (mandatory)
-  -t, --tag string     Tag name (mandatory)
+      --dry-run         Do not create a release and assets actually
+  -h, --help            help for release
+  -u, --owner string    GitHub repository owner (mandatory)
+  -r, --repo string     GitHub repository name (mandatory)
+  -t, --tag string      Tag name (mandatory)
+      --target string   Branch name or commit SHA of a tag. Unused if the Git tag already exists (default: the default branch)
 ```
 
 

--- a/adaptors/cmd/cmd_test.go
+++ b/adaptors/cmd/cmd_test.go
@@ -424,9 +424,10 @@ func TestCmd_Run(t *testing.T) {
 			releaseUseCase := mock_release.NewMockInterface(ctrl)
 			releaseUseCase.EXPECT().
 				Do(ctx, release.Input{
-					Repository: git.RepositoryID{Owner: "owner", Name: "repo"},
-					TagName:    "v1.0.0",
-					Paths:      []string{"file1", "file2"},
+					Repository:              git.RepositoryID{Owner: "owner", Name: "repo"},
+					TagName:                 "v1.0.0",
+					TargetBranchOrCommitSHA: "COMMIT_SHA",
+					Paths:                   []string{"file1", "file2"},
 				})
 			r := Runner{
 				NewLogger:         newLogger(t, logger.Option{}),
@@ -441,6 +442,7 @@ func TestCmd_Run(t *testing.T) {
 				"-u", "owner",
 				"-r", "repo",
 				"-t", "v1.0.0",
+				"--target", "COMMIT_SHA",
 				"file1",
 				"file2",
 			}

--- a/adaptors/github/release.go
+++ b/adaptors/github/release.go
@@ -36,8 +36,9 @@ func (c *GitHub) GetReleaseByTagOrNil(ctx context.Context, repo git.RepositoryID
 func (c *GitHub) CreateRelease(ctx context.Context, r git.Release) (*git.Release, error) {
 	c.Logger.Debugf("Creating a release %+v", r)
 	release, _, err := c.Client.CreateRelease(ctx, r.ID.Repository.Owner, r.ID.Repository.Name, &github.RepositoryRelease{
-		TagName: github.String(r.TagName.Name()),
-		Name:    github.String(r.Name),
+		Name:            github.String(r.Name),
+		TagName:         github.String(r.TagName.Name()),
+		TargetCommitish: github.String(r.TargetCommitish),
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("GitHub API error: %w", err)
@@ -47,8 +48,9 @@ func (c *GitHub) CreateRelease(ctx context.Context, r git.Release) (*git.Release
 			Repository: r.ID.Repository,
 			InternalID: release.GetID(),
 		},
-		TagName: git.TagName(release.GetTagName()),
-		Name:    release.GetName(),
+		TagName:         git.TagName(release.GetTagName()),
+		TargetCommitish: release.GetTargetCommitish(),
+		Name:            release.GetName(),
 	}, nil
 }
 

--- a/domain/git/release.go
+++ b/domain/git/release.go
@@ -8,9 +8,10 @@ type ReleaseID struct {
 
 // Release represents a release associated to a tag.
 type Release struct {
-	ID      ReleaseID
-	TagName TagName
-	Name    string
+	ID              ReleaseID
+	TagName         TagName
+	TargetCommitish string // branch name or commit SHA
+	Name            string
 }
 
 // ReleaseAsset represents a release asset.

--- a/usecases/release/release.go
+++ b/usecases/release/release.go
@@ -24,10 +24,11 @@ type Interface interface {
 }
 
 type Input struct {
-	Repository git.RepositoryID
-	TagName    git.TagName
-	Paths      []string
-	DryRun     bool
+	Repository              git.RepositoryID
+	TagName                 git.TagName
+	TargetBranchOrCommitSHA string // optional
+	Paths                   []string
+	DryRun                  bool
 }
 
 // Release create a release with the files to the tag in the repository.
@@ -67,9 +68,10 @@ func (u *Release) Do(ctx context.Context, in Input) error {
 			return nil
 		}
 		release, err = u.GitHub.CreateRelease(ctx, git.Release{
-			ID:      git.ReleaseID{Repository: in.Repository},
-			TagName: in.TagName,
-			Name:    in.TagName.Name(),
+			ID:              git.ReleaseID{Repository: in.Repository},
+			Name:            in.TagName.Name(),
+			TagName:         in.TagName,
+			TargetCommitish: in.TargetBranchOrCommitSHA,
 		})
 		if err != nil {
 			return xerrors.Errorf("could not create a release: %w", err)

--- a/usecases/release/release_test.go
+++ b/usecases/release/release_test.go
@@ -25,9 +25,10 @@ func TestRelease_Do(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		in := Input{
-			Repository: targetRepositoryID,
-			TagName:    targetTagName,
-			Paths:      []string{"path"},
+			Repository:              targetRepositoryID,
+			TagName:                 targetTagName,
+			TargetBranchOrCommitSHA: "TARGET_COMMIT",
+			Paths:                   []string{"path"},
 		}
 		fileSystem := mock_fs.NewMockInterface(ctrl)
 		fileSystem.EXPECT().FindFiles([]string{"path"}, gomock.Any()).Return(theFiles, nil)
@@ -40,16 +41,18 @@ func TestRelease_Do(t *testing.T) {
 				ID: git.ReleaseID{
 					Repository: targetRepositoryID,
 				},
-				TagName: targetTagName,
-				Name:    targetTagName.Name(),
+				TagName:         targetTagName,
+				Name:            targetTagName.Name(),
+				TargetCommitish: "TARGET_COMMIT",
 			}).
 			Return(&git.Release{
 				ID: git.ReleaseID{
 					Repository: targetRepositoryID,
 					InternalID: 1234567890,
 				},
-				TagName: targetTagName,
-				Name:    targetTagName.Name(),
+				TagName:         targetTagName,
+				Name:            targetTagName.Name(),
+				TargetCommitish: "TARGET_COMMIT",
 			}, nil)
 		gitHub.EXPECT().
 			CreateReleaseAsset(ctx, git.ReleaseAsset{


### PR DESCRIPTION
This will add `release --target` option to create a tag on a desired commit.