### PR TITLE
Fix a broken Renovate configugration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "extends": [
     "github>int128/renovate-base",
-    "github>int128/go-renovate-config:github-actions#v1.2.0",
+    "github>int128/go-renovate-config:github-actions#v1.4.1",
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "extends": [
     "github>int128/renovate-base",
-    "github>int128/go-actions",
+    "github>int128/go-renovate-config:github-actions#v1.2.0",
   ],
 }


### PR DESCRIPTION
Currently, Renovate configuration is invalid so Renovate stops working.

- https://github.com/int128/ghcp/issues/315

> Action Required: Fix Renovate Configuration
> There is an error with this repository's Renovate configuration that needs to be fixed. As a precaution, Renovate will stop PRs until it is resolved.
> 
> Error type: Cannot find preset's package (github>int128/go-actions)

Actually, preset `github>int128/go-actions` (default.json) doesn't exist.

https://github.com/int128/go-actions/tree/e3907480a8f8924752a5d53946bb89fdc30f72d0

It seems the preset was moved to `github>int128/go-renovate-config:github-actions`.

- https://github.com/int128/go-renovate-config
- https://github.com/int128/go-actions/commit/fc4d9587076ba351ce3e4af49bbf28a285b2eead

This pull request would fix Renovate Configuration, so Renovate would start working.