### PR TITLE
Skip PR creation only if open PR exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ To create a pull request from `feature` branch of `OWNER/REPO` repository to the
 ghcp pull-request -r OWNER/REPO -b feature --base-repo UPSTREAM/REPO --base feature --title TITLE --body BODY
 ```
 
-If a pull request already exists, ghcp do nothing.
+If an open pull request already exists, ghcp do nothing.
 
 You can set the following options.
 

--- a/acceptance_test/Makefile
+++ b/acceptance_test/Makefile
@@ -20,8 +20,8 @@ test:
 		--title "ghcp: acceptance-test $(BRANCH_PREFIX)" \
 		--body "ref: #$(GITHUB_PR_NUMBER)"
 	$(GHCP) pull-request $(GHCP_FLAGS) -b $(BRANCH_PREFIX)-feature --base $(BRANCH_PREFIX)-master \
-		--title "ghcp: acceptance-test $(BRANCH_PREFIX)" \
-		--body "This should not create a new pull request"
+		--title "ghcp: acceptance-test: This should not be created" \
+		--body "ref: #$(GITHUB_PR_NUMBER)"
 
 .PHONY: clean-up
 clean-up:

--- a/acceptance_test/Makefile
+++ b/acceptance_test/Makefile
@@ -19,6 +19,9 @@ test:
 	$(GHCP) pull-request $(GHCP_FLAGS) -b $(BRANCH_PREFIX)-feature --base $(BRANCH_PREFIX)-master \
 		--title "ghcp: acceptance-test $(BRANCH_PREFIX)" \
 		--body "ref: #$(GITHUB_PR_NUMBER)"
+	$(GHCP) pull-request $(GHCP_FLAGS) -b $(BRANCH_PREFIX)-feature --base $(BRANCH_PREFIX)-master \
+		--title "ghcp: acceptance-test $(BRANCH_PREFIX)" \
+		--body "This should not create a new pull request"
 
 .PHONY: clean-up
 clean-up:

--- a/pkg/usecases/pullrequest/pull_request_test.go
+++ b/pkg/usecases/pullrequest/pull_request_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/int128/ghcp/mocks/github.com/int128/ghcp/pkg/github_mock"
 	"github.com/int128/ghcp/pkg/git"
 	"github.com/int128/ghcp/pkg/github"
+	"github.com/shurcooL/githubv4"
 )
 
 func TestPullRequest_Do(t *testing.T) {
@@ -53,7 +54,7 @@ func TestPullRequest_Do(t *testing.T) {
 				t.Errorf("err wants nil but %+v", err)
 			}
 		})
-		t.Run("when the pull request already exists", func(t *testing.T) {
+		t.Run("when an open pull request already exists", func(t *testing.T) {
 			gitHub := github_mock.NewMockInterface(t)
 			gitHub.EXPECT().
 				QueryForPullRequest(ctx, github.QueryForPullRequestInput{
@@ -65,7 +66,12 @@ func TestPullRequest_Do(t *testing.T) {
 				Return(&github.QueryForPullRequestOutput{
 					CurrentUserName:     "you",
 					HeadBranchCommitSHA: "HeadCommitSHA",
-					PullRequestURL:      "https://github.com/octocat/Spoon-Knife/pull/19445",
+					ExistingPullRequests: []github.ExistingPullRequest{
+						{
+							State: githubv4.PullRequestStateOpen,
+							URL:   "https://github.com/octocat/Spoon-Knife/pull/19445",
+						},
+					},
 				}, nil)
 			useCase := PullRequest{
 				GitHub: gitHub,


### PR DESCRIPTION
## Problem to solve
When a closed pull request exists, ghcp does not create a new pull request.
