### PR TITLE
Support release when tag is pushed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ on:
       - '*.go'
       - go.*
       - Makefile
+    tags:
+      - v*
   pull_request:
     branches:
       - master
@@ -28,13 +30,14 @@ jobs:
   create:
     runs-on: ubuntu-slim
     timeout-minutes: 10
+    outputs:
+      draft-release-name: ${{ steps.create-draft-release.outputs.draft-release-name }}
     permissions:
       contents: write
     steps:
-      - id: create
-        uses: int128/go-release-action/create-draft-release@d41b0078a58c1c5360be181566937fdd79caef6e # v2.4.0
-        with:
-          release-name: ${{ case(github.event_name == 'push', 'next', '') }}
+      - if: github.event_name == 'push'
+        id: create-draft-release
+        uses: int128/go-release-action/create-draft-release@9e1d6ec29fc6ffc2ba55f631baf4a73017d228e1 # v2.5.0
 
   build:
     needs: create
@@ -73,7 +76,7 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
       - run: make
-      - uses: int128/go-release-action@d41b0078a58c1c5360be181566937fdd79caef6e # v2.4.0
+      - uses: int128/go-release-action@9e1d6ec29fc6ffc2ba55f631baf4a73017d228e1 # v2.5.0
         with:
           binary: ghcp
-          release-name: ${{ case(github.event_name == 'push', 'next', '') }}
+          release-name: ${{ needs.create.outputs.draft-release-name }}


### PR DESCRIPTION
Updated the release workflow to use version 2.5.0 of the go-release-action and added tag support for releases.